### PR TITLE
Remove lowercase restriction on mongo database names

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -18,14 +18,12 @@ exports.Connection = internals.Connection = function (options) {
 
      - empty string is not valid
      - cannot contain space, "*<>:|?
-     - should be all lowercase
      - limited to 64 bytes (after conversion to UTF-8)
      - admin, local and config are reserved
      */
 
     Hoek.assert(options.partition !== 'admin' && options.partition !== 'local' && options.partition !== 'config', 'Cache partition name cannot be "admin", "local", or "config" when using MongoDB');
     Hoek.assert(options.partition.length < 64, 'Cache partition must be less than 64 bytes when using MongoDB');
-    Hoek.assert(options.partition === options.partition.toLowerCase(), 'Cache partition name must be all lowercase when using MongoDB');
 
     this.settings = options;
     this.client = null;


### PR DESCRIPTION
Not sure if you guys will be ok with this change or not.

I've had to make it because modulus.io seems to always generate database names that contain an upper case character (at least all of the 10 or so that I created last night contained one). So without this, I can't deploy the new hapi app that I'm working on to modulus.io.

Fwiw, the documentation for mongo doesn't mention anything about upper case characters in its restrictions on database names:

http://docs.mongodb.org/manual/reference/limits/#Restrictions%20on%20Database%20Names
