### PR TITLE
Close the redis connection on error

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -39,6 +39,7 @@ internals.Connection.prototype.start = function (callback) {
     this.client.on('error', function (err) {
 
         if (wasHandled === false) {
+            self.client.end();
             wasHandled = true;
             self.client = null;                                                     // Set to null so that Connnection.isReady returns false
             return callback(err);


### PR DESCRIPTION
Before losing the reference to `this.client`, forcibly close the
connection to the Redis server.

If the Redis server couldn’t be reached in the first place
(`ECONNREFUSED` on connection), this also prevents node-redis from
auto-reconnecting indefinitely.

---

I couldn't come up with a simple test case, but here is a meaningful use case:

When the Redis server isn't available, `client.stop()` doesn't work as expected, as something keeps the event loop busy:

``` javascript
var Catbox = require('./');

var client = new Catbox.Client({
    engine: 'redis',
    partition: 'examples'
});

client.start(function (err) {
    console.log(err);
    client.stop();
});
```

outputs:

```
~/tmp ❯❯❯ node test.js
[Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED]

```

(the program hangs there forever and needs to be stopped using `^C`)

Whereas if the Redis server is available:

```
~/tmp ❯❯❯ node test.js
undefined
~/tmp ❯❯❯ 
```
