### PR TITLE
Add ability to pass the Redis client to the Redis store

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `Client` object provides a low-level cache abstraction. The object is constr
             - `host` - the Redis server hostname. Defaults to `'127.0.0.1'`.
             - `port` - the Redis server port. Defaults to `6379`.
             - `password` - the Redis authentication password when required.
+            - `client` - the existing Redis client object you normally get from redis.createClient()
         - Riak:
             - `host` - the Riak server hostname. Defaults to `127.0.0.1`.
             - `port` - the Riak PBC port. Defaults to `8087`.

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -26,10 +26,14 @@ internals.Connection.prototype.start = function (callback) {
         return callback();
     }
 
-    this.client = Redis.createClient(this.settings.port, this.settings.host);
+    if (this.settings.client) {
+        this.client = this.settings.client;
+    } else {
+        this.client = Redis.createClient(this.settings.port, this.settings.host);
 
-    if (this.settings.password) {
-        this.client.auth(this.settings.password);
+        if (this.settings.password) {
+            this.client.auth(this.settings.password);
+        }
     }
 
     // Listen to errors


### PR DESCRIPTION
In our code organisation, all redis client creation is delegated to a special service that bind events for debugging and other stuffs...
So we would like to pass an instance of redis client directly to Catbox.
