### PR TITLE
Allow undefined values in expires assertion

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -227,7 +227,7 @@ internals.Policy.compile = function (options, serverSide) {
 
     // Validate rule
 
-    Hoek.assert(!!options.expiresIn ^ !!options.expiresAt, 'Rule must include one of expiresIn or expiresAt but not both', options);                                                // XOR
+    Hoek.assert((!!options.expiresIn ^ !!options.expiresAt) || (options.expiresIn === undefined || options.expiresAt === undefined), 'Rule must include one of expiresIn or expiresAt but not both', options);                                                // XOR
     Hoek.assert(!options.expiresAt || !options.staleIn || options.staleIn < 86400000, 'staleIn must be less than 86400000 milliseconds (one day) when using expiresAt');
     Hoek.assert(!options.expiresIn || !options.staleIn || options.staleIn < options.expiresIn, 'staleIn must be less than expiresIn');
     Hoek.assert(!(!!options.staleIn ^ !!options.staleTimeout), 'Rule must include both of staleIn and staleTimeout or none');                                      // XNOR


### PR DESCRIPTION
Using server.route.config.cache.expiresIn = 0 in hapi causes the following error: "Error: Rule must include one of expiresIn or expiresAt but not both {"expiresIn":0}". 

The call to Catbox.Policy() here https://github.com/spumko/hapi/blob/master/lib/route.js#L84 passes an undefined expiresAt attribute in hapi's route.js code. My first thought was to check for undefined before calling Catbox.Policy() in route.js but I found that Catbox.Policy is similarly called with both expiresIn and expiresAt in hapi's pack.js so maybe there's some kind of convention that I'm not sure about so I ended up changing the assert instead.

Of course if you trigger the code in pack.js by running "var cache = server.cache('countries', { expiresIn: 0 });" the error is not generated because of the truthy condition (https://github.com/spumko/hapi/blob/master/lib/pack.js#L669) that sets the settings parameter. The settings parameter ends up not getting any attribute added to it which doesn't throw an error and probably behaves as expected when setting expiresIn = 0 anyway.
