### PR TITLE
Use catbox specific domain for clients and timeout

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Hoek = require('hoek');
+var IndependentDomain = require('./independent-domain');
 
 
 // Declare internals
@@ -38,25 +39,45 @@ module.exports = internals.Client = function (engine, options) {
 
 internals.Client.prototype.stop = function () {
 
-    this.connection.stop();
+    var self = this;
+
+    IndependentDomain.run(function() {
+
+        self.connection.stop();
+    });
 };
 
 
 internals.Client.prototype.start = function (callback) {
 
-    this.connection.start(callback);
+    var self = this;
+
+    IndependentDomain.run(function() {
+
+        self.connection.start(callback);
+    });
 };
 
 
 internals.Client.prototype.isReady = function () {
 
-    return this.connection.isReady();
+    var self = this;
+
+    return IndependentDomain.run(function() {
+
+        return self.connection.isReady();
+    });
 };
 
 
 internals.Client.prototype.validateSegmentName = function (name) {
 
-    return this.connection.validateSegmentName(name);
+    var self = this;
+
+    return IndependentDomain.run(function() {
+
+        return self.connection.validateSegmentName(name);
+    });
 };
 
 
@@ -78,78 +99,89 @@ internals.Client.prototype.get = function (key, callback) {
         return callback(new Error('Invalid key'));
     }
 
-    this.connection.get(key, function (err, result) {
+    IndependentDomain.run(function() {
 
-        if (err) {
-            // Connection error
-            return callback(err);
-        }
+        self.connection.get(key, function (err, result) {
 
-        if (!result ||
-            result.item === undefined ||
-            result.item === null) {
+            if (err) {
+                // Connection error
+                return callback(err);
+            }
 
-            // Not found
-            return callback(null, null);
-        }
+            if (!result ||
+                result.item === undefined ||
+                result.item === null) {
 
-        var now = Date.now();
-        var expires = result.stored + result.ttl;
-        var ttl = expires - now;
-        if (ttl <= 0) {
-            // Expired
-            return callback(null, null);
-        }
+                // Not found
+                return callback(null, null);
+            }
 
-        // Valid
+            var now = Date.now();
+            var expires = result.stored + result.ttl;
+            var ttl = expires - now;
+            if (ttl <= 0) {
+                // Expired
+                return callback(null, null);
+            }
 
-        var cached = {
-            item: result.item,
-            stored: result.stored,
-            ttl: ttl
-        };
+            // Valid
 
-        return callback(null, cached);
+            var cached = {
+                item: result.item,
+                stored: result.stored,
+                ttl: ttl
+            };
+
+            return callback(null, cached);
+        });
     });
 };
 
 
 internals.Client.prototype.set = function (key, value, ttl, callback) {
 
-    if (!this.connection.isReady()) {
-        // Disconnected
-        return callback(new Error('Disconnected'));
-    }
+    var self = this;
 
-    if (!key || !key.id || !key.segment) {
-        return callback(new Error('Invalid key'));
-    }
+    IndependentDomain.run(function() {
 
-    if (ttl > 2147483647) {                                                         // Math.pow(2, 31)
-        return callback(new Error('Invalid ttl (greater than 2147483647)'));
-    }
+        if (!self.connection.isReady()) {
+            // Disconnected
+            return callback(new Error('Disconnected'));
+        }
 
-    if (ttl <= 0) {
-        // Not cachable (or bad rules)
-        return callback();
-    }
+        if (!key || !key.id || !key.segment) {
+            return callback(new Error('Invalid key'));
+        }
 
-    this.connection.set(key, value, ttl, callback);
+        if (ttl > 2147483647) {                                                         // Math.pow(2, 31)
+            return callback(new Error('Invalid ttl (greater than 2147483647)'));
+        }
+
+        if (ttl <= 0) {
+            // Not cachable (or bad rules)
+            return callback();
+        }
+
+        self.connection.set(key, value, ttl, callback);
+    });
 };
 
 
 internals.Client.prototype.drop = function (key, callback) {
 
-    if (!this.connection.isReady()) {
-        // Disconnected
-        return callback(new Error('Disconnected'));
-    }
+    var self = this;
 
-    if (!key || !key.id || !key.segment) {
-        return callback(new Error('Invalid key'));
-    }
+    IndependentDomain.run(function() {
 
-    this.connection.drop(key, callback);           // Always drop, regardless of caching rules
+        if (!self.connection.isReady()) {
+            // Disconnected
+            return callback(new Error('Disconnected'));
+        }
+
+        if (!key || !key.id || !key.segment) {
+            return callback(new Error('Invalid key'));
+        }
+
+        self.connection.drop(key, callback);           // Always drop, regardless of caching rules
+    });
 };
-
-

--- a/lib/independent-domain.js
+++ b/lib/independent-domain.js
@@ -1,0 +1,19 @@
+
+var internals = {
+  domain: undefined
+};
+
+// Executes `exec` in an independent domain from any existing domains. This allows us to have
+// long running callbacks that are independent of the current domain.
+module.exports.run = function(exec) {
+
+  if (process.domain) {
+    // Avoid requiring the child domain unless we need it as there are side effects for processes
+    // that have not otherwise required it.
+    internals.domain = internals.domain || require('domain').create();
+
+    return internals.domain.run(exec);
+  } else {
+    return exec();
+  }
+};

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Hoek = require('hoek');
+var IndependentDomain = require('./independent-domain');
 
 
 // Declare internals
@@ -150,8 +151,11 @@ internals.Policy.prototype.getOrGenerate = function (id, generateFunc, callback)
                     wasCallbackCalled = true;
                     return callback(null, cached.item, cached, report);
                 };
-                
-                setTimeout(timerFunc, self.rule.staleTimeout);
+
+                IndependentDomain.run(function() {
+
+                    setTimeout(timerFunc, self.rule.staleTimeout);
+                });
             }
         }
 

--- a/test/independent-domain.js
+++ b/test/independent-domain.js
@@ -1,0 +1,48 @@
+// Load modules
+
+var Lab = require('lab');
+var IndependentDomain = require('../lib/independent-domain');
+var Domain = require('domain');
+
+// Test shortcuts
+
+var expect = Lab.expect;
+var beforeEach = Lab.beforeEach;
+var afterEach = Lab.afterEach;
+var describe = Lab.experiment;
+var it = Lab.test;
+
+describe('Independent Domain', function() {
+
+  var existingDomain;
+
+  beforeEach(function(done) {
+
+    existingDomain = process.domain;
+    done();
+  });
+  afterEach(function(done) {
+
+    process.domain = existingDomain;
+    done();
+  });
+
+
+  it('should execute in a separate domain if one exists', function(done) {
+
+    var domain = Domain.create();
+    domain.run(function() {
+
+      IndependentDomain.run(function() {
+
+        expect(process.domain).to.not.equal(domain);
+        done();
+      });
+    });
+  });
+  it('should execute without a domain', function(done) {
+
+    process.domain = undefined;
+    IndependentDomain.run(done);
+  });
+});

--- a/test/policy.js
+++ b/test/policy.js
@@ -2,7 +2,7 @@
 
 var Lab = require('lab');
 var Catbox = require('..');
-
+var Domain = require('domain');
 
 // Declare internals
 
@@ -1102,6 +1102,43 @@ describe('Policy', function () {
                             }, 10);
                         });
                     }, 10);
+                });
+            });
+        });
+
+        it('freshens stale objects independent of current domain', function (done) {
+
+            var rule = {
+                expiresIn: 100,
+                staleIn: 20,
+                staleTimeout: 5
+            };
+
+            var domain = Domain.create();
+
+            domain.enter();
+            setup(rule, 6, false, 100, function (get) {
+
+                get('test', function (err, value1, cached) {
+
+                    expect(value1.gen).to.equal(1);        // Fresh
+                    setTimeout(function () {
+
+                        get('test', function (err, value2, cached) {
+
+                            expect(value2.gen).to.equal(1);        // Stale
+                            domain.dispose();
+
+                            setTimeout(function () {
+
+                                get('test', function (err, value3, cached) {
+
+                                    expect(value3.gen).to.equal(2);        // Fresh
+                                    done();
+                                });
+                            }, 3);
+                        });
+                    }, 21);
                 });
             });
         });


### PR DESCRIPTION
Avoids both leaks due to domains being retained for cache operations and the
possibility that disposed domains can interrupt our long running cache
processes.

Fixes #63
