### PR TITLE
Adjust test timing to be deterministic.

### DIFF
--- a/test/policy.js
+++ b/test/policy.js
@@ -809,9 +809,9 @@ describe('Policy', function () {
             it('returns new object when stale has less than staleTimeout time left', function (done) {
 
                 var rule = {
-                    expiresIn: 25,
+                    expiresIn: 31,
                     staleIn: 15,
-                    staleTimeout: 5,
+                    staleTimeout: 15,
                     generateFunc: function (id, next) {
 
                         return next(null, { gen: ++gen });


### PR DESCRIPTION
Adjusted test was relying on 1ms timing difference, which is not reliable (https://travis-ci.org/hapijs/catbox). Updated timing have 3 ms between events, which seems to be reliable enough. This also caused test failure for #105 
