### PR TITLE
Expose cache engine connection isReady as public method

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,5 +131,6 @@ The `Policy` object provides the following methods:
     - `id` - the unique item identifier (within the policy segment).
     - `callback` - a function with the signature `function(err)`.
 - `ttl(created)` - given a `created` timestamp in milliseconds, returns the time-to-live left based on the configured rules.
-- `rules(options) - changes the policy rules after construction (note that items already stored will not be affected) where:
+- `rules(options)` - changes the policy rules after construction (note that items already stored will not be affected) where:
     - `options` - the same `options` as the `Policy` constructor.
+- `isReady()` - returns whether the cache engine determines itself as ready.

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ The `Policy` object provides the following methods:
 - `ttl(created)` - given a `created` timestamp in milliseconds, returns the time-to-live left based on the configured rules.
 - `rules(options)` - changes the policy rules after construction (note that items already stored will not be affected) where:
     - `options` - the same `options` as the `Policy` constructor.
-- `isReady()` - returns whether the cache engine determines itself as ready.
+- `isReady()` - `true` if cache engine determines itself as ready, `false`if it is not ready or if there is no cache engine set.

--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ The `Policy` object provides the following methods:
 - `ttl(created)` - given a `created` timestamp in milliseconds, returns the time-to-live left based on the configured rules.
 - `rules(options)` - changes the policy rules after construction (note that items already stored will not be affected) where:
     - `options` - the same `options` as the `Policy` constructor.
-- `isReady()` - `true` if cache engine determines itself as ready, `false`if it is not ready or if there is no cache engine set.
+- `isReady()` - returns `true` if cache engine determines itself as ready, `false` if it is not ready or if there is no cache engine set.

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -348,3 +348,9 @@ internals.Policy.ttl = function (rule, created, now) {
 
     return 0;                                                                       // No rule
 };
+
+
+internals.Policy.prototype.isReady = function () {
+
+    return this._cache.connection.isReady();
+};

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -352,5 +352,9 @@ internals.Policy.ttl = function (rule, created, now) {
 
 internals.Policy.prototype.isReady = function () {
 
+    if (!this._cache) {
+        return false;
+    }
+
     return this._cache.connection.isReady();
 };

--- a/test/policy.js
+++ b/test/policy.js
@@ -1866,6 +1866,14 @@ describe('Policy', function () {
                 done();
             });
         });
+
+        it('returns false when no cache client provided', function (done) {
+
+            var policy = new Catbox.Policy({ expiresIn: 1 });
+
+            expect(policy.isReady()).to.equal(false);
+            done();
+        });
     });
 
 });

--- a/test/policy.js
+++ b/test/policy.js
@@ -1875,7 +1875,6 @@ describe('Policy', function () {
             done();
         });
     });
-
 });
 
 

--- a/test/policy.js
+++ b/test/policy.js
@@ -1833,6 +1833,41 @@ describe('Policy', function () {
             done();
         });
     });
+
+    describe('isReady()', function () {
+
+        it('returns cache engine readiness', function (done) {
+            var expected = true;
+            var engine = {
+                start: function (callback) {
+
+                    callback();
+                },
+                isReady: function () {
+
+                    return expected;
+                },
+                get: function (key, callback) {
+
+                    callback(new Error());
+                },
+                validateSegmentName: function () {
+
+                    return null;
+                }
+            };
+            var client = new Catbox.Client(engine);
+            var policy = new Catbox.Policy({}, client, 'test');
+
+
+            client.start(function () {
+
+                expect(policy.isReady()).to.equal(expected);
+                done();
+            });
+        });
+    });
+
 });
 
 


### PR DESCRIPTION
It is useful to be able to check whether the cache engine is ready, particularly when implementing client cache reconnection schemes. 

Since the function already exists on the engine that is passed in, it is trivial to expose this useful method as a public function on the cache policy.