### PR TITLE
Prefix keys with a `'+'` when using object as a hash

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -42,12 +42,13 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
     // Check if request is already pending
 
     var id = (key && typeof key === 'object') ? key.id : key;
-    if (this._pendings[id]) {
-        this._pendings[id].push(callback);
+    var pendingsId = '+' + id;
+    if (this._pendings[pendingsId]) {
+        this._pendings[pendingsId].push(callback);
         return;
     }
 
-    this._pendings[id] = [callback];
+    this._pendings[pendingsId] = [callback];
 
     // Lookup in cache
 
@@ -169,6 +170,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report, callba
 
 internals.Policy.prototype._finalize = function (id, err, value, cached, report) {
 
+    id = '+' + id;
     var pendings = this._pendings[id];
     delete this._pendings[id];
 

--- a/test/policy.js
+++ b/test/policy.js
@@ -44,6 +44,29 @@ describe('Policy', function () {
         });
     });
 
+    it('works with special property names', function (done) {
+
+        var client = new Catbox.Client(Import);
+        var policy = new Catbox.Policy({ expiresIn: 1000 }, client, 'test');
+
+        client.start(function (err) {
+
+            expect(err).to.not.exist();
+
+            policy.set('__proto__', '123', null, function (err) {
+
+                expect(err).to.not.exist();
+
+                policy.get('__proto__', function (err, value, cached, report) {
+
+                    expect(err).to.not.exist();
+                    expect(value).to.equal('123');
+                    done();
+                });
+            });
+        });
+    });
+
     it('finds nothing when using empty policy rules', function (done) {
 
         var client = new Catbox.Client(Import);


### PR DESCRIPTION
Prevent from crashing when a "special" property name (like `__proto__`)
is used.