### PR TITLE
Allow time zone specification for expiresAt values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ The object is constructed using `new Policy(options, [cache, segment])` where:
     - `expiresIn` - relative expiration expressed in the number of milliseconds since the item was saved in the cache. Cannot be used
       together with `expiresAt`.
     - `expiresAt` - time of day expressed in 24h notation using the 'HH:MM' format, at which point all cache records for the route
-      expire. Uses local time. Cannot be used together with `expiresIn`.
+      expire. Uses local time if `timezone` is not used. Cannot be used together with `expiresIn`.
+    - `timezone` - time zone that the `expiresAt` time should be interpreted relative to. The time zone can be expressed either as a
+      fixed offset using the '+-HH:MM' format (ex. '-08:00') or as an IANA time zone name (ex. 'America/Los_Angeles'). When using a named
+      time zone, daylight savings time will be taken into account automatically if it is recognized by that time zone.
     - `generateFunc` - a function used to generate a new cache item if one is not found in the cache when calling `get()`. The method's
       signature is `function(id, next)` where:
         - `id` - the `id` string or object provided to the `get()` method.

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -4,6 +4,8 @@ var Boom = require('boom');
 var Hoek = require('hoek');
 var Joi = require('joi');
 
+var moment = require('moment-timezone');
+
 
 // Declare internals
 
@@ -215,6 +217,7 @@ internals.Policy.prototype.ttl = function (created) {
 internals.schema = Joi.object({
     expiresIn: Joi.number().integer().min(1),
     expiresAt: Joi.string().regex(/^\d\d?\:\d\d$/),
+    timezone: [Joi.string().regex(/^[-+]\d\d?\:?\d\d$/), Joi.string().regex(/^\w+\/\w+(\/\w+)?$/)],
     staleIn: [Joi.number().integer().min(1).max(86400000 - 1), Joi.func()],               // One day - 1 (max is inclusive)
     staleTimeout: Joi.number().integer().min(1),
     generateFunc: Joi.func(),
@@ -229,6 +232,7 @@ internals.schema = Joi.object({
     shared: Joi.any()
 })
     .without('expiresIn', 'expiresAt')
+    .with('timezone', 'expiresAt')
     .with('staleIn', 'generateFunc')
     .with('generateTimeout', 'generateFunc')
     .with('dropOnError', 'generateFunc')
@@ -275,13 +279,34 @@ internals.Policy.compile = function (options, serverSide) {
     // Expiration
 
     if (hasExpiresAt) {
+        var time;
+        var timezone;
+
+        if (options.timezone) {
+            if (/^[+-]\d\d?\:?\d\d$/.test(options.timezone)) {
+                // Time zone offset format
+                time = moment(options.expiresAt + options.timezone, 'HH:mmZ');      // Offset is accounted for at construction
+            }
+            else {
+                // Named time zone format
+                if (! moment.tz.zone(options.timezone)) {
+                    throw new Error('Unknown time zone name');
+                }
+                time = moment(options.expiresAt, 'HH:mm');
+                timezone = options.timezone;
+            }
+        }
+        else {
+            // No time zone
+            time = moment(options.expiresAt, 'HH:mm');
+        }
 
         // expiresAt
 
-        var time = /^(\d\d?):(\d\d)$/.exec(options.expiresAt);
         rule.expiresAt = {
-            hours: parseInt(time[1], 10),
-            minutes: parseInt(time[2], 10)
+            hours: time.hours(),
+            minutes: time.minutes(),
+            timezone: timezone
         };
     }
     else {
@@ -330,12 +355,16 @@ internals.Policy.ttl = function (rule, created, now) {
             return 0;
         }
 
-        var expiresAt = new Date(created);                                          // Compare expiration time on the same day
-        expiresAt.setHours(rule.expiresAt.hours);
-        expiresAt.setMinutes(rule.expiresAt.minutes);
-        expiresAt.setSeconds(0);
-        expiresAt.setMilliseconds(0);
-        var expires = expiresAt.getTime();
+        var expiresAt = moment(created);                                            // Compare expiration time on the same day
+        if (rule.expiresAt.timezone) {
+            expiresAt.tz(rule.expiresAt.timezone);                                  // Need to set the timezone to account for DST.
+        }
+        expiresAt.hours(rule.expiresAt.hours);
+        expiresAt.minutes(rule.expiresAt.minutes);
+        expiresAt.seconds(0);
+        expiresAt.milliseconds(0);
+
+        var expires = expiresAt.valueOf();
 
         if (expires <= created) {
             expires += internals.day;                                               // Move to tomorrow

--- a/package.json
+++ b/package.json
@@ -11,17 +11,18 @@
     "node": ">=0.10.32"
   },
   "dependencies": {
-    "boom":  "2.x.x",
+    "boom": "2.x.x",
     "hoek": "2.x.x",
-    "joi":  "6.x.x"
+    "joi": "6.x.x",
+    "moment-timezone": "^0.4.0"
   },
   "devDependencies": {
     "code": "1.x.x",
     "lab": "5.x.x"
   },
   "scripts": {
-      "test": "lab -a code -t 100 -L",
-      "test-cov-html": "lab -a code -r html -o coverage.html"
+    "test": "lab -a code -t 100 -L",
+    "test-cov-html": "lab -a code -r html -o coverage.html"
   },
   "license": "BSD-3-Clause"
 }

--- a/test/policy.js
+++ b/test/policy.js
@@ -1352,6 +1352,74 @@ describe('Policy', function () {
             done();
         });
 
+        it('returns the ttl factoring the created time (positive time zone offset)', function (done) {
+
+            var config = {
+                expiresAt: '21:00',
+                timezone: '+0530'
+            };
+
+            var rules = new Catbox.Policy.compile(config);
+
+            var created = Date.UTC(2014, 9, 6, 13, 0, 0);           // Sat Sep 06 2014 13:00:00 UTC time
+            var now = Date.UTC(2014, 9, 6, 15, 0, 0);               // Sat Sep 06 2014 15:00:00 UTC time
+
+            var ttl = Catbox.Policy.ttl(rules, created, now);
+            expect(ttl).to.equal(1800000);                          // 30 minutes left
+            done();
+        });
+
+        it('returns the ttl factoring the created time (negative time zone offset)', function (done) {
+
+            var config = {
+                expiresAt: '10:00',
+                timezone: '-05:30'
+            };
+
+            var rules = new Catbox.Policy.compile(config);
+
+            var created = Date.UTC(2014, 9, 6, 13, 0, 0);           // Sat Sep 06 2014 13:00:00 UTC time
+            var now = Date.UTC(2014, 9, 6, 15, 0, 0);               // Sat Sep 06 2014 15:00:00 UTC time
+
+            var ttl = Catbox.Policy.ttl(rules, created, now);
+            expect(ttl).to.equal(1800000);                          // 30 minutes left
+            done();
+        });
+
+        it('returns the ttl factoring the created time (time zone name)', function (done) {
+
+            var config = {
+                expiresAt: '09:00',
+                timezone: 'America/Los_Angeles'                     // PST -0800
+            };
+
+            var rules = new Catbox.Policy.compile(config);
+
+            var created = Date.UTC(2014, 12, 6, 13, 0, 0);          // Sat Dec 06 2014 13:00:00 UTC time
+            var now = Date.UTC(2014, 12, 6, 15, 0, 0);              // Sat Dec 06 2014 15:00:00 UTC time
+
+            var ttl = Catbox.Policy.ttl(rules, created, now);
+            expect(ttl).to.equal(7200000);                          // 2 hours left
+            done();
+        });
+
+        it('returns the ttl factoring the created time (dst time zone name)', function (done) {
+
+            var config = {
+                expiresAt: '09:00',
+                timezone: 'America/Los_Angeles'                     // PDT -0700
+            };
+
+            var rules = new Catbox.Policy.compile(config);
+
+            var created = Date.UTC(2014, 9, 6, 13, 0, 0);           // Sat Sep 06 2014 13:00:00 UTC time
+            var now = Date.UTC(2014, 9, 6, 15, 0, 0);               // Sat Sep 06 2014 15:00:00 UTC time
+
+            var ttl = Catbox.Policy.ttl(rules, created, now);
+            expect(ttl).to.equal(3600000);                          // 1 hour left
+            done();
+        });
+
         it('returns expired when created in the future', function (done) {
 
             var config = {
@@ -1495,6 +1563,94 @@ describe('Policy', function () {
             };
 
             expect(fn).to.not.throw();
+            done();
+        });
+
+        it('allows a rule with expiresAt and time zone (positive offset)', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: '+05:30' }, true);
+            };
+
+            expect(fn).to.not.throw();
+            done();
+        });
+
+        it('allows a rule with expiresAt and time zone (short offset)', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: '+530' }, true);
+            };
+
+            expect(fn).to.not.throw();
+            done();
+        });
+
+        it('requires a sign on a time zone offset', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: '0530' }, true);
+            };
+
+            expect(fn).to.throw(/fails to match the required pattern/);
+            done();
+        });
+
+        it('allows a rule with expiresAt and time zone (negative offset)', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: '-05:30' }, true);
+            };
+
+            expect(fn).to.not.throw();
+            done();
+        });
+
+        it('allows a rule with expiresAt and time zone (name)', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: 'America/Los_Angeles' }, true);
+            };
+
+            expect(fn).to.not.throw();
+            done();
+        });
+
+        it('throws error with time zone but no expiresAt', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ timezone: '+05:30' }, true);
+            };
+
+            expect(fn).to.throw(/"timezone" missing required peer "expiresAt"/);
+            done();
+        });
+
+        it('throws error with a malformed time zone', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: '#badtimezone' }, true);
+            };
+
+            expect(fn).to.throw(/fails to match the required pattern/);
+            done();
+        });
+
+        it('throws error with non-existant time zone name', function (done) {
+
+            var fn = function () {
+
+                Catbox.policy.compile({ expiresAt: '09:00', timezone: 'foo/bar' }, true);
+            };
+
+            expect(fn).to.throw('Unknown time zone name');
             done();
         });
 


### PR DESCRIPTION
This change introduces a 'timezone' option for cache policy objects
that determines which time zone the 'expiresAt' time is relative to.
Time zones may be specified either as a fixed offset (ex. -0800) or
as a IANA time zone name (ex. America/Los_Angeles). When using a
named time zone, daylight savings time will be accounted for
automatically.

Closes #112.