### PR TITLE
Monitoring events for policy operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,32 @@ The `Policy` object provides the following methods:
 - `rules(options)` - changes the policy rules after construction (note that items already stored will not be affected) where:
     - `options` - the same `options` as the `Policy` constructor.
 - `isReady()` - returns `true` if cache engine determines itself as ready, `false` if it is not ready or if there is no cache engine set.
+
+##### Events
+
+`Policy` objects emit several events for the purposes of monitoring error rates, performance, etc. of cache operations. All events are of the same
+form and have a `report` argument with the following attributes:
+
+- `error` - the error object if the operation failed.
+- `id` - the id of the entry being operated on.
+- `msec` - the time that elapsed before the operation called back.
+
+The following events are emitted:
+
+- `get` - records the time it took to fetch an item from the cache (before any `generateFunc` processing).
+- `set` - records the time it took to write an item to the cache (whether explicit or as a result of generating a new entry).
+- `generate` - records the time it took to generate the entry (regardless of `staleTimeout` and `generateTimeout` settings).
+- `drop` - records the time it took to invalidate an entry in the cache.
+
+```js
+var client = new Catbox.Client(. . .);
+var policy = new Catbox.Policy(policyOptions, client, 'segment');
+
+policy.on('set', function (report) {
+
+    console.log('It took ' + report.msec + 'ms to write "' + report.id + '" to the cache.');
+    if (report.error) {
+        console.log('Writing failed with: ' + report.error.message);
+    }
+});
+```

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -1,6 +1,7 @@
 // Load modules
 
 var Boom = require('boom');
+var EventEmitter = require('events').EventEmitter;
 var Hoek = require('hoek');
 var Joi = require('joi');
 
@@ -16,6 +17,8 @@ exports = module.exports = internals.Policy = function (options, cache, segment)
 
     Hoek.assert(this.constructor === internals.Policy, 'Cache Policy must be instantiated using new');
 
+    EventEmitter.call(this);
+
     this._cache = cache;
     this._pendings = {};                                        // id -> [callbacks]
     this.rules(options);
@@ -27,6 +30,8 @@ exports = module.exports = internals.Policy = function (options, cache, segment)
         this._segment = segment;
     }
 };
+
+Hoek.inherits(internals.Policy, EventEmitter);
 
 
 internals.Policy.prototype.rules = function (options) {
@@ -69,6 +74,8 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
             cached.isStale = (staleIn ? (Date.now() - cached.stored) >= staleIn : false);
             report.isStale = cached.isStale;
         }
+
+        self.emit('get', { error: err, id: id, msec: report.msec });
 
         // No generate method
 
@@ -138,8 +145,16 @@ internals.Policy.prototype._generate = function (id, key, cached, report, callba
 
     // Generate new value
 
+    var timer = new Hoek.Timer();
+    var emitReport = function (err) {
+
+        self.emit('generate', { error: err, id: id, msec: timer.elapsed() });
+    };
+
     try {
         this.rule.generateFunc.call(null, key, function (err, value, ttl) {
+
+            emitReport(err);
 
             // Error (if dropOnError is not set to false) or not cached
 
@@ -163,6 +178,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report, callba
         });
     }
     catch (err) {
+        emitReport(err);
         return finalize(id, err, null, null, report);
     }
 };
@@ -184,13 +200,22 @@ internals.Policy.prototype.set = function (key, value, ttl, callback) {
 
     callback = callback || Hoek.ignore;
 
+    var id = (key && typeof key === 'object') ? key.id : key;
+    var self = this;
+    var timer = new Hoek.Timer();
+
+    var finalize = function (err) {
+
+        self.emit('set', { error: err, id: id, msec: timer.elapsed() });
+        callback(err);
+    };
+
     if (!this._cache) {
-        return callback(null);
+        return finalize(null);
     }
 
     ttl = ttl || internals.Policy.ttl(this.rule);
-    var id = (key && typeof key === 'object') ? key.id : key;
-    this._cache.set({ segment: this._segment, id: id }, value, ttl, callback);
+    this._cache.set({ segment: this._segment, id: id }, value, ttl, finalize);
 };
 
 
@@ -198,11 +223,19 @@ internals.Policy.prototype.drop = function (id, callback) {
 
     callback = callback || Hoek.ignore;
 
+    var self = this;
+    var timer = new Hoek.Timer();
+    var finalize = function (err, result) {
+
+        self.emit('drop', { error: err, id: id, msec: timer.elapsed() });
+        callback(err, result);
+    };
+
     if (!this._cache) {
-        return callback(null);
+        return finalize(null);
     }
 
-    this._cache.drop({ segment: this._segment, id: id }, callback);
+    this._cache.drop({ segment: this._segment, id: id }, finalize);
 };
 
 


### PR DESCRIPTION
This change causes policy objects to emit monitoring events for
all cache operations. All events include the id, time, and error
(if one occured) associated with the operation.

Resolves #70.