### PR TITLE
Require generateTimeout with generateFunc.

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -126,7 +126,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report, callba
             }, this.rule.staleTimeout);
         }
     }
-    else if (this.rule.generateTimeout) {
+    else {                                              // generateTimeout is required if generateFunc is set
 
         // Set item generation timeout (when not in cache)
 
@@ -230,8 +230,8 @@ internals.schema = Joi.object({
 })
     .without('expiresIn', 'expiresAt')
     .with('staleIn', 'generateFunc')
-    .with('generateTimeout', 'generateFunc')
     .with('dropOnError', 'generateFunc')
+    .and('generateFunc', 'generateTimeout')
     .and('staleIn', 'staleTimeout');
 
 


### PR DESCRIPTION
This change requires that a 'generateTimeout' is specified any time
a 'generateFunc' value is provided. This is to prevent the get
queue from getting stuck if the 'generateFunc' fails to call back.

Fixes #115.