### PR TITLE
Adding pendingGenerateTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The object is constructed using `new Policy(options, [cache, segment])` where:
       and will instead pass back the cache error. Defaults to `true`.
     - `generateIgnoreWriteError` - if `false`, an upstream cache write error will be passed back with the generated value when calling
       the `get()` method. Defaults to `true`.
+    - `pendingGenerateTimeout` - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed. Defaults to 0, no blocking of concurrent generateFunc calls beyond staleTimeout.
 - `cache` - a `Client` instance (which has already been started).
 - `segment` - required when `cache` is provided. The segment name used to isolate cached items within the cache partition.
 

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -20,6 +20,7 @@ exports = module.exports = internals.Policy = function (options, cache, segment)
 
     this._cache = cache;
     this._pendings = {};                                        // id -> [callbacks]
+    this._pendingGenerateCall = {};                             // id -> boolean
     this.rules(options);
 
     this.stats = {
@@ -140,40 +141,62 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
 
     ++this.stats.generates;                                     // Record generation before call in case it times out
 
-    try {
-        this.rule.generateFunc.call(null, key, (generateError, value, ttl) => {
+    if (!this._pendingGenerateCall[id]) {
 
-            const finalize = (err) => {
+        internals.setupPendingGenerateCall(this, id);
 
-                const error = generateError || (this.rule.generateIgnoreWriteError ? null : err);
-                if (cached &&
-                    error &&
-                    !this.rule.dropOnError) {
+        try {
+            this._callGenerateFunc(id, key, cached, report, respond);
+        }
+        catch (err) {
+            delete this._pendingGenerateCall[id];
+            return respond(this, id, err, null, null, report);
+        }
+    }
+};
 
-                    return respond(this, id, error, cached.item, cached, report);
-                }
+internals.setupPendingGenerateCall = function (policy, id) {
 
-                return respond(this, id, error, value, null, report);       // Ignored if stale value already returned
-            };
+    if (policy.rule.pendingGenerateTimeout) {
+        policy._pendingGenerateCall[id] = true;
+        setTimeout(() => {
 
-            // Error (if dropOnError is not set to false) or not cached
+            delete policy._pendingGenerateCall[id];
+        }, policy.rule.pendingGenerateTimeout);
+    }
+};
 
-            if ((generateError && this.rule.dropOnError) ||
-                ttl === 0) {                                    // null or undefined means use policy
+internals.Policy.prototype._callGenerateFunc = function (id, key, cached, report, respond) {
 
-                return this.drop(id, finalize);                 // Invalidate cache
+    this.rule.generateFunc.call(null, key, (generateError, value, ttl) => {
+
+        delete this._pendingGenerateCall[id];
+
+        const finalize = (err) => {
+
+            const error = generateError || (this.rule.generateIgnoreWriteError ? null : err);
+            if (cached &&
+                error &&
+                !this.rule.dropOnError) {
+
+                return respond(this, id, error, cached.item, cached, report);
             }
 
-            if (!generateError) {
-                return this.set(id, value, ttl, finalize);      // Lazy save (replaces stale cache copy with late-coming fresh copy)
-            }
+            return respond(this, id, error, value, null, report);       // Ignored if stale value already returned
+        };
 
-            return finalize();
-        });
-    }
-    catch (err) {
-        return respond(this, id, err, null, null, report);
-    }
+        // Error (if dropOnError is not set to false) or not cached
+
+        if ((generateError && this.rule.dropOnError) || ttl === 0) {                                    // null or undefined means use policy
+            return this.drop(id, finalize);                 // Invalidate cache
+        }
+
+        if (!generateError) {
+            return this.set(id, value, ttl, finalize);      // Lazy save (replaces stale cache copy with late-coming fresh copy)
+        }
+
+        return finalize();
+    });
 };
 
 
@@ -262,6 +285,7 @@ internals.schema = Joi.object({
     generateOnReadError: Joi.boolean(),
     generateIgnoreWriteError: Joi.boolean(),
     dropOnError: Joi.boolean(),
+    pendingGenerateTimeout: Joi.number().integer().min(1),
 
     // Ignored external keys (hapi)
 
@@ -317,6 +341,7 @@ internals.Policy.compile = function (options, serverSide) {
     Hoek.assert(!options.staleIn || serverSide, 'Cannot use stale options without server-side caching');
     Hoek.assert(!options.staleTimeout || !hasExpiresIn || options.staleTimeout < options.expiresIn, 'staleTimeout must be less than expiresIn');
     Hoek.assert(!options.staleTimeout || !hasExpiresIn || typeof options.staleIn === 'function' || options.staleTimeout < (options.expiresIn - options.staleIn), 'staleTimeout must be less than the delta between expiresIn and staleIn');
+    Hoek.assert(!options.staleTimeout || !options.pendingGenerateTimeout || options.staleTimeout < options.pendingGenerateTimeout, 'pendingGenerateTimeout must be greater than staleTimeout if specified');
 
     // Expiration
 
@@ -351,6 +376,7 @@ internals.Policy.compile = function (options, serverSide) {
         }
 
         rule.dropOnError = options.dropOnError !== undefined ? options.dropOnError : true;                                          // Defaults to true
+        rule.pendingGenerateTimeout = options.pendingGenerateTimeout !== undefined ? options.pendingGenerateTimeout : 0;            // Defaults to zero
     }
 
     rule.generateOnReadError = options.generateOnReadError !== undefined ? options.generateOnReadError : true;                      // Defaults to true


### PR DESCRIPTION
Adding pendingGenerateTimeout to allow a low staleTimeout, while still limiting concurrent generateFunc calls over a longer period