### PR TITLE
Feature to sepcify timeout on underlying cahce engine get operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The object is constructed using `new Policy(options, [cache, segment])` where:
     - `generateIgnoreWriteError` - if `false`, an upstream cache write error will be passed back with the generated value when calling
       the `get()` method. Defaults to `true`.
     - `pendingGenerateTimeout` - number of milliseconds while generateFunc call is in progress for a given id, before a subsequent generateFunc call is allowed. Defaults to 0, no blocking of concurrent generateFunc calls beyond staleTimeout.
+    - `onReadTimeout` - number of milliseconds to wait till the cache object responds, after this timeout, generateFunc would be invoked to get the value.
 - `cache` - a `Client` instance (which has already been started).
 - `segment` - required when `cache` is provided. The segment name used to isolate cached items within the cache partition.
 

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -202,7 +202,23 @@ internals.Policy.prototype._get = function (id, callback) {
         return Hoek.nextTick(callback)(null, null);
     }
 
-    this._cache.get({ segment: this._segment, id: id }, callback);
+    var done = false;
+
+    if (this.rule.onReadTimeout) {
+        setTimeout(() => {
+            if (!done) {
+                done = true;
+                return callback(null, null);
+            }
+        }, this.rule.onReadTimeout);
+    }
+
+    this._cache.get({ segment: this._segment, id: id }, function (err, cached) {
+        if (!done) {
+            done = true;
+            callback(err, cached);
+        }
+    });
 };
 
 
@@ -287,6 +303,7 @@ internals.schema = Joi.object({
     generateIgnoreWriteError: Joi.boolean(),
     dropOnError: Joi.boolean(),
     pendingGenerateTimeout: Joi.number().integer().min(1),
+    onReadTimeout: Joi.number().integer().min(1),
 
     // Ignored external keys (hapi)
 
@@ -382,6 +399,8 @@ internals.Policy.compile = function (options, serverSide) {
 
     rule.generateOnReadError = options.generateOnReadError !== undefined ? options.generateOnReadError : true;                      // Defaults to true
     rule.generateIgnoreWriteError = options.generateIgnoreWriteError !== undefined ? options.generateIgnoreWriteError : true;       // Defaults to true
+
+    rule.onReadTimeout = options.onReadTimeout;
 
     return rule;
 };

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -214,7 +214,7 @@ internals.Policy.prototype._get = function (id, callback) {
         }, this.rule.onReadTimeout);
     }
 
-    this._cache.get({ segment: this._segment, id: id }, function (err, cached) {
+    this._cache.get({ segment: this._segment, id: id }, (err, cached) => {
 
         if (!done) {
             done = true;

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -206,6 +206,7 @@ internals.Policy.prototype._get = function (id, callback) {
 
     if (this.rule.onReadTimeout) {
         setTimeout(() => {
+
             if (!done) {
                 done = true;
                 return callback(null, null);
@@ -214,6 +215,7 @@ internals.Policy.prototype._get = function (id, callback) {
     }
 
     this._cache.get({ segment: this._segment, id: id }, function (err, cached) {
+
         if (!done) {
             done = true;
             callback(err, cached);

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -202,7 +202,7 @@ internals.Policy.prototype._get = function (id, callback) {
         return Hoek.nextTick(callback)(null, null);
     }
 
-    var done = false;
+    let done = false;
 
     if (this.rule.onReadTimeout) {
         setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "catbox",
     "description": "Multi-strategy object caching service",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "repository": "git://github.com/hapijs/catbox",
     "main": "lib/index.js",
     "keywords": [

--- a/test/policy.js
+++ b/test/policy.js
@@ -374,6 +374,42 @@ describe('Policy', () => {
             }
         });
 
+        it('returns null on get when cache client timesout ', (done) => {
+
+            const engine = {
+                start: function (callback) {
+
+                    callback();
+                },
+                isReady: function () {
+
+                    return true;
+                },
+                get: function (key, callback) {
+
+                    //Do not make a callback
+                },
+                validateSegmentName: function () {
+
+                    return null;
+                }
+            };
+            const policyConfig = {
+                expiresIn: 50000,
+                onReadTimeout: 200
+            };
+
+            const client = new Catbox.Client(engine);
+            const policy = new Catbox.Policy(policyConfig, client, 'test');
+
+            policy.get('test1', (err, value, cached, report) => {
+                expect(err).to.not.exist();
+                expect(value).to.not.exist();
+                expect(policy.stats).to.deep.equal({ sets: 0, gets: 1, hits: 0, stales: 0, generates: 0, errors: 0 });
+                done();
+            });
+        });
+
         describe('generate', () => {
 
             it('returns falsey items', (done) => {


### PR DESCRIPTION
Added onReatTimeout, this specifies timeout duration for get operation on cache client.