### PR TITLE
Unref timers in policy to allow exit when run as script

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -124,7 +124,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
             setTimeout(() => {
 
                 return respond(this, id, null, cached.item, cached, report);
-            }, this.rule.staleTimeout);
+            }, this.rule.staleTimeout).unref();
         }
     }
     else if (this.rule.generateTimeout) {
@@ -134,7 +134,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
         setTimeout(() => {
 
             return respond(this, id, Boom.serverTimeout(), null, null, report);
-        }, this.rule.generateTimeout);
+        }, this.rule.generateTimeout).unref();
     }
 
     // Generate new value
@@ -148,7 +148,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
             setTimeout(() => {
 
                 delete this._pendingGenerateCall[pendingId];
-            }, this.rule.pendingGenerateTimeout);
+            }, this.rule.pendingGenerateTimeout).unref();
         }
 
         try {


### PR DESCRIPTION
Timers prevent the script from exiting after the execution of the main thread has finished. This PR fixes it by not requiring the timers to fire before the script can exit.