### PR TITLE
Ensure generate timeout is triggered when staleTimeout > ttl

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -114,18 +114,20 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
 internals.Policy.prototype._generate = function (id, key, cached, report) {
 
     const respond = Hoek.once(internals.respond);
+    let ttl = -1;
 
     if (cached) {                                       // Must be stale
 
         // Set stale timeout
 
-        cached.ttl = cached.ttl - this.rule.staleTimeout;       // Adjust TTL for when the timeout is invoked (staleTimeout must be valid if isStale is true)
-        if (cached.ttl > 0) {
-            setTimeout(() => {
+        ttl = cached.ttl = cached.ttl - this.rule.staleTimeout;       // Adjust TTL for when the timeout is invoked (staleTimeout must be valid if isStale is true)
+    }
 
-                return respond(this, id, null, cached.item, cached, report);
-            }, this.rule.staleTimeout);
-        }
+    if (ttl > 0) {
+        setTimeout(() => {
+
+            return respond(this, id, null, cached.item, cached, report);
+        }, this.rule.staleTimeout);
     }
     else if (this.rule.generateTimeout) {
 


### PR DESCRIPTION
This fixes a **critical** issue where a generate that never completes can cause `get()` calls to queue up indefinitely even though `generateTimeout` is specified.

This issue is especially critical in combination with `pendingGenerateTimeout`, which will _never_ call `respond()` if there is a pending generate.