### PR TITLE
Fix for "Can't drop method without arguments #165"

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -248,14 +248,21 @@ internals.Policy.prototype.set = function (key, value, ttl, callback) {
 
 internals.Policy.prototype.drop = function (key, callback) {
 
-    callback = callback || Hoek.ignore;
+    const len = arguments.length;
+    const hasKey = len === 2;
+    const lastArg = arguments[len - 1];
+    key = hasKey ? key : '';
+
+    callback = (typeof lastArg === 'function' ? lastArg : null) || Hoek.ignore;
 
     if (!this._cache) {
         return callback(null);
     }
 
     const id = (key && typeof key === 'object') ? key.id : key;
-    if (!id) {
+
+    // ok to have empty string
+    if (!id && typeof id !== 'string') {
         return callback(new Error('Invalid key'));
     }
 

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -253,7 +253,7 @@ internals.Policy.prototype.drop = function (key, callback) {
     const lastArg = arguments[len - 1];
     key = hasKey ? key : '';
 
-    callback = (typeof lastArg === 'function' ? lastArg : null) || Hoek.ignore;
+    callback = typeof lastArg === 'function' ? lastArg : Hoek.ignore;
 
     if (!this._cache) {
         return callback(null);

--- a/test/policy.js
+++ b/test/policy.js
@@ -1753,16 +1753,12 @@ describe('Policy', () => {
 
             const policy = new Catbox.Policy({ expiresIn: 1 });
 
-            expect(() => {
+            policy.drop((err) => {
 
-                policy.drop((err) => {
+                expect(err).to.not.exist();
+                done();
+            });
 
-                    expect(err).to.not.exist();
-                    done();
-                });
-            }).to.not.throw();
-
-            done();
         });
 
         it('ignores missing callback', (done) => {

--- a/test/policy.js
+++ b/test/policy.js
@@ -1749,6 +1749,22 @@ describe('Policy', () => {
             });
         });
 
+        it('ignores missing key', (done) => {
+
+            const policy = new Catbox.Policy({ expiresIn: 1 });
+
+            expect(() => {
+
+                policy.drop((err) => {
+
+                    expect(err).to.not.exist();
+                    done();
+                });
+            }).to.not.throw();
+
+            done();
+        });
+
         it('ignores missing callback', (done) => {
 
             const policy = new Catbox.Policy({ expiresIn: 1 });
@@ -1809,6 +1825,17 @@ describe('Policy', () => {
 
                 expect(err).to.exist();
                 expect(err.message).to.equal('Invalid key');
+                done();
+            });
+        });
+
+        it('accepts empty string', (done) => {
+
+            const policy = new Catbox.Policy({ expiresIn: 1 });
+
+            policy.drop('', (err) => {
+
+                expect(err).to.not.exist();
                 done();
             });
         });


### PR DESCRIPTION

It also accepts empty string as key.


Case example:

**foo.handler.js**

`server.methods.foo.findAll(req.query, (err, results) => { });`

**foo.methods.js**

```
const methods = {
    findAll: (condition, next) => {
        Model.find(condition).exec(next);
    }
};

module.exports = [
{
    name: 'foo.findAll',
    method: methods.findAll,
    options: {
      cache: {
        expiresIn: ...,
        generateTimeout: ...,
        cache: 'redisCache'
      },
      generateKey: function(obj) {
        // object to querystring. Empty string if condition is empty
        return cacheKeyGenerator.generate(obj);
      }
    }
  },
]
```

Observation: query string can be empty which results in empty string. Trying to drop an empty string throws an error: `Invalid key`
