### PR TITLE
Add a link to the catbox-disk backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ each service must be manually installed via npm or package dependencies manually
 - [Couchbase](https://github.com/cmfatih/catbox-couchbase)
 - [Aerospike](https://github.com/ooogway/catbox-aerospike)
 - [LevelDB](https://github.com/mshick/catbox-multilevel)
+- [Local Disk](https://github.com/mirusresearch/catbox-disk)
 
 
 ### `Client`


### PR DESCRIPTION
Add a link to the `catbox-disk` local disk cache backend we've built and been using in production.  Slower than redis, faster than a speeding S3, and it survives instance restarts/reboots.  Let me know if you have questions or feel like it's a bad fit for the project. Thanks!