### PR TITLE
Timeout with pendingGenerateTimeout period over cache expiration

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -143,7 +143,14 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
     // Generate new value
 
     const pendingId = ('+' + id);
-    if (!this._pendingGenerateCall[pendingId]) {                // Check if a generate call is already in progress
+    // Check if a generate call is already in progress
+    // Note about !cached:
+    // We need to regenerate a value in the rare case where we reach this code with a pending generate call
+    // and no cache
+    // ex: one get() call get served a stale cache just before cache expiration, triggering the generate function
+    // and another call just after expiration lands here and never receives a response
+    // TODO: ideally the second call should get the response from the pending generate function once completed
+    if (!cached || !this._pendingGenerateCall[pendingId]) {
         ++this.stats.generates;                                 // Record generation before call in case it times out
 
         if (this.rule.pendingGenerateTimeout) {


### PR DESCRIPTION
## Description
If the cache expires while a pendingGenerateTimeout period is running without any "pending response", consecutive `get()` within the period result in timeouts.

Related to issue #177


## Solution
Here we force re-generating a value for those consecutive `get()` that would be lost otherwise but it's not ideal as it ignores the initial purpose of `pendingGenerateTimeout` option...

Any thoughts for a better option ?
