### PR TITLE
Pendings refactor

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -195,7 +195,7 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
         ++this.stats.generates;                                 // Record generation before call in case it times out
 
         if (this.rule.pendingGenerateTimeout) {
-            this._pendingGenerateCall[pendingId] = true;
+            this._pendingGenerateCall[pendingId] = pending;
             setTimeout(() => {
 
                 delete this._pendingGenerateCall[pendingId];
@@ -209,6 +209,8 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
             delete this._pendingGenerateCall[pendingId];
             return pending.send(err, null, null, report);
         }
+    } else {
+        this._pendingGenerateCall[pendingId] = pending;
     }
 };
 
@@ -217,6 +219,7 @@ internals.Policy.prototype._callGenerateFunc = function (pending, key, cached, r
 
     this.rule.generateFunc.call(null, key, (generateError, value, ttl) => {
 
+        pending = this._pendingGenerateCall['+' + pending.id] || pending;
         delete this._pendingGenerateCall['+' + pending.id];
 
         const finalize = (err) => {

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -14,12 +14,44 @@ const internals = {
 };
 
 
+internals.toBoundCallback = function (callback) {
+
+    return process.domain ? process.domain.bind(callback) : callback;
+};
+
+
+internals.PendingResponse = function (id, callback) {
+
+    this.id = id;
+    this.callbacks = [internals.toBoundCallback(callback)];
+};
+
+
+internals.PendingResponse.prototype.add = function (callback) {
+
+    this.callbacks.push(internals.toBoundCallback(callback));     // Explicitly bind callback to its process.domain (_finalize might get called from a different active process.domain)
+};
+
+
+internals.PendingResponse.prototype.send = function (err, value, cached, report) {
+
+    const length = this.callbacks.length;
+    for (let i = 0; i < length; ++i) {
+        Hoek.nextTick(this.callbacks[i])(err, value, cached, report);
+    }
+
+    this.callbacks = [];
+
+    return length;
+};
+
+
 exports = module.exports = internals.Policy = function (options, cache, segment) {
 
     Hoek.assert(this instanceof internals.Policy, 'Cache Policy must be instantiated using new');
 
     this._cache = cache;
-    this._pendings = {};                                        // id -> [callbacks]
+    this._pendings = {};                                        // id -> PendingResponse
     this._pendingGenerateCall = {};                             // id -> boolean
     this.rules(options);
 
@@ -56,11 +88,11 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
     const id = (key && typeof key === 'object') ? key.id : key;
     const pendingsId = '+' + id;                                  // Prefix to avoid conflicts with JS internals (e.g. __proto__)
     if (this._pendings[pendingsId]) {
-        this._pendings[pendingsId].push(process.domain ? process.domain.bind(callback) : callback);     // Explicitly bind callback to its process.domain (_finalize might get called from a different active process.domain)
+        this._pendings[pendingsId].add(callback);
         return;
     }
 
-    this._pendings[pendingsId] = [callback];
+    const pending = this._pendings[pendingsId] = new internals.PendingResponse(id, callback);
 
     // Lookup in cache
 
@@ -95,7 +127,7 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
         if (!this.rule.generateFunc ||
             (err && !this.rule.generateOnReadError)) {
 
-            return internals.respond(this, id, err, cached ? cached.item : null, cached, report);
+            return internals.respond(this, pending, err, cached ? cached.item : null, cached, report);
         }
 
         // Check if found and fresh
@@ -103,15 +135,15 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
         if (cached &&
             !cached.isStale) {
 
-            return internals.respond(this, id, null, cached.item, cached, report);
+            return internals.respond(this, pending, null, cached.item, cached, report);
         }
 
-        return this._generate(id, key, cached, report);
+        return this._generate(pending, key, cached, report);
     });
 };
 
 
-internals.Policy.prototype._generate = function (id, key, cached, report) {
+internals.Policy.prototype._generate = function (pending, key, cached, report) {
 
     const respond = Hoek.once(internals.respond);
 
@@ -127,7 +159,7 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
 
         setTimeout(() => {
 
-            return respond(this, id, null, cached.item, cached, report);
+            return respond(this, pending, null, cached.item, cached, report);
         }, this.rule.staleTimeout);
     }
     else if (this.rule.generateTimeout) {
@@ -136,13 +168,13 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
 
         setTimeout(() => {
 
-            return respond(this, id, Boom.serverUnavailable(), null, null, report);
+            return respond(this, pending, Boom.serverUnavailable(), null, null, report);
         }, this.rule.generateTimeout);
     }
 
     // Generate new value
 
-    const pendingId = ('+' + id);
+    const pendingId = ('+' + pending.id);
     if (!this._pendingGenerateCall[pendingId]) {                // Check if a generate call is already in progress
         ++this.stats.generates;                                 // Record generation before call in case it times out
 
@@ -155,21 +187,21 @@ internals.Policy.prototype._generate = function (id, key, cached, report) {
         }
 
         try {
-            this._callGenerateFunc(id, key, cached, report, respond);
+            this._callGenerateFunc(pending, key, cached, report);
         }
         catch (err) {
             delete this._pendingGenerateCall[pendingId];
-            return respond(this, id, err, null, null, report);
+            return respond(this, pending, err, null, null, report);
         }
     }
 };
 
 
-internals.Policy.prototype._callGenerateFunc = function (id, key, cached, report, respond) {
+internals.Policy.prototype._callGenerateFunc = function (pending, key, cached, report) {
 
     this.rule.generateFunc.call(null, key, (generateError, value, ttl) => {
 
-        delete this._pendingGenerateCall['+' + id];
+        delete this._pendingGenerateCall['+' + pending.id];
 
         const finalize = (err) => {
 
@@ -178,20 +210,20 @@ internals.Policy.prototype._callGenerateFunc = function (id, key, cached, report
                 error &&
                 !this.rule.dropOnError) {
 
-                return respond(this, id, error, cached.item, cached, report);
+                return internals.respond(this, pending, error, cached.item, cached, report);
             }
 
-            return respond(this, id, error, value, null, report);       // Ignored if stale value already returned
+            return internals.respond(this, pending, error, value, null, report);       // Ignored if stale value already returned
         };
 
         // Error (if dropOnError is not set to false) or not cached
 
         if ((generateError && this.rule.dropOnError) || ttl === 0) {                                    // null or undefined means use policy
-            return this.drop(id, finalize);                 // Invalidate cache
+            return this.drop(pending.id, finalize);                 // Invalidate cache
         }
 
         if (!generateError) {
-            return this.set(id, value, ttl, finalize);      // Lazy save (replaces stale cache copy with late-coming fresh copy)
+            return this.set(pending.id, value, ttl, finalize);      // Lazy save (replaces stale cache copy with late-coming fresh copy)
         }
 
         return finalize();
@@ -209,19 +241,15 @@ internals.Policy.prototype._get = function (id, callback) {
 };
 
 
-internals.respond = function (policy, id, err, value, cached, report) {
+internals.respond = function (policy, pending, err, value, cached, report) {
 
-    id = '+' + id;
-    const pendings = policy._pendings[id];
-    delete policy._pendings[id];
+    const pendingsId = '+' + pending.id;
+    delete policy._pendings[pendingsId];
 
-    const length = pendings.length;
-    for (let i = 0; i < length; ++i) {
-        Hoek.nextTick(pendings[i])(err, value, cached, report);
-    }
+    const count = pending.send(err, value, cached, report);
 
-    if (report.isStale !== undefined) {
-        policy.stats.hits = policy.stats.hits + length;
+    if (count > 0 && report.isStale !== undefined) {
+        policy.stats.hits = policy.stats.hits + count;
     }
 };
 

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -62,8 +62,8 @@ exports = module.exports = internals.Policy = function (options, cache, segment)
     Hoek.assert(this instanceof internals.Policy, 'Cache Policy must be instantiated using new');
 
     this._cache = cache;
-    this._pendings = {};                                        // id -> PendingResponse
-    this._pendingGenerateCall = {};                             // id -> boolean
+    this._pendings = Object.create(null);                       // id -> PendingResponse
+    this._pendingGenerateCall = Object.create(null);            // id -> boolean
     this.rules(options);
 
     this.stats = {
@@ -97,15 +97,14 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
     // Check if request is already pending
 
     const id = (key && typeof key === 'object') ? key.id : key;
-    const pendingsId = '+' + id;                                  // Prefix to avoid conflicts with JS internals (e.g. __proto__)
-    if (this._pendings[pendingsId]) {
-        this._pendings[pendingsId].add(callback);
+    if (this._pendings[id]) {
+        this._pendings[id].add(callback);
         return;
     }
 
-    const pending = this._pendings[pendingsId] = new internals.PendingResponse(id, callback, (count, report) => {
+    const pending = this._pendings[id] = new internals.PendingResponse(id, callback, (count, report) => {
 
-        delete this._pendings[pendingsId];
+        delete this._pendings[id];
 
         if (count > 0 && report.isStale !== undefined) {
             this.stats.hits = this.stats.hits + count;
@@ -190,15 +189,14 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
 
     // Generate new value
 
-    const pendingId = ('+' + pending.id);
-    if (!this._pendingGenerateCall[pendingId]) {                // Check if a generate call is already in progress
+    if (!this._pendingGenerateCall[pending.id]) {                // Check if a generate call is already in progress
         ++this.stats.generates;                                 // Record generation before call in case it times out
 
         if (this.rule.pendingGenerateTimeout) {
-            this._pendingGenerateCall[pendingId] = pending;
+            this._pendingGenerateCall[pending.id] = pending;
             setTimeout(() => {
 
-                delete this._pendingGenerateCall[pendingId];
+                delete this._pendingGenerateCall[pending.id];
             }, this.rule.pendingGenerateTimeout);
         }
 
@@ -206,11 +204,12 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
             this._callGenerateFunc(pending, key, cached, report);
         }
         catch (err) {
-            delete this._pendingGenerateCall[pendingId];
+            delete this._pendingGenerateCall[pending.id];
             return pending.send(err, null, null, report);
         }
-    } else {
-        this._pendingGenerateCall[pendingId] = pending;
+    }
+    else {
+        this._pendingGenerateCall[pending.id] = pending;
     }
 };
 
@@ -219,8 +218,8 @@ internals.Policy.prototype._callGenerateFunc = function (pending, key, cached, r
 
     this.rule.generateFunc.call(null, key, (generateError, value, ttl) => {
 
-        pending = this._pendingGenerateCall['+' + pending.id] || pending;
-        delete this._pendingGenerateCall['+' + pending.id];
+        pending = this._pendingGenerateCall[pending.id] || pending;
+        delete this._pendingGenerateCall[pending.id];
 
         const finalize = (err) => {
 

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -20,10 +20,12 @@ internals.toBoundCallback = function (callback) {
 };
 
 
-internals.PendingResponse = function (id, callback) {
+internals.PendingResponse = function (id, addCallback, onDidSend) {
 
     this.id = id;
-    this.callbacks = [internals.toBoundCallback(callback)];
+    this.callbacks = [internals.toBoundCallback(addCallback)];
+    this.onDidSend = onDidSend;
+    this.timeoutTimer = null;
 };
 
 
@@ -40,9 +42,18 @@ internals.PendingResponse.prototype.send = function (err, value, cached, report)
         Hoek.nextTick(this.callbacks[i])(err, value, cached, report);
     }
 
+    clearTimeout(this.timeoutTimer);
     this.callbacks = [];
 
-    return length;
+    return this.onDidSend(length, report);
+};
+
+
+internals.PendingResponse.prototype.setTimeout = function (fn, timeoutMs) {
+
+    clearTimeout(this.timeoutTimer);
+
+    this.timeoutTimer = setTimeout(fn, timeoutMs);
 };
 
 
@@ -92,7 +103,14 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
         return;
     }
 
-    const pending = this._pendings[pendingsId] = new internals.PendingResponse(id, callback);
+    const pending = this._pendings[pendingsId] = new internals.PendingResponse(id, callback, (count, report) => {
+
+        delete this._pendings[pendingsId];
+
+        if (count > 0 && report.isStale !== undefined) {
+            this.stats.hits = this.stats.hits + count;
+        }
+    });
 
     // Lookup in cache
 
@@ -127,7 +145,7 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
         if (!this.rule.generateFunc ||
             (err && !this.rule.generateOnReadError)) {
 
-            return internals.respond(this, pending, err, cached ? cached.item : null, cached, report);
+            return pending.send(err, cached ? cached.item : null, cached, report);
         }
 
         // Check if found and fresh
@@ -135,7 +153,7 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
         if (cached &&
             !cached.isStale) {
 
-            return internals.respond(this, pending, null, cached.item, cached, report);
+            return pending.send(null, cached.item, cached, report);
         }
 
         return this._generate(pending, key, cached, report);
@@ -144,8 +162,6 @@ internals.Policy.prototype.get = function (key, callback) {     // key: string o
 
 
 internals.Policy.prototype._generate = function (pending, key, cached, report) {
-
-    const respond = Hoek.once(internals.respond);
 
     if (cached) {                                       // Must be stale
 
@@ -157,18 +173,18 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
     if (cached &&
         cached.ttl > 0) {
 
-        setTimeout(() => {
+        pending.setTimeout(() => {
 
-            return respond(this, pending, null, cached.item, cached, report);
+            return pending.send(null, cached.item, cached, report);
         }, this.rule.staleTimeout);
     }
     else if (this.rule.generateTimeout) {
 
         // Set item generation timeout (when not in cache)
 
-        setTimeout(() => {
+        pending.setTimeout(() => {
 
-            return respond(this, pending, Boom.serverUnavailable(), null, null, report);
+            return pending.send(Boom.serverUnavailable(), null, null, report);
         }, this.rule.generateTimeout);
     }
 
@@ -191,7 +207,7 @@ internals.Policy.prototype._generate = function (pending, key, cached, report) {
         }
         catch (err) {
             delete this._pendingGenerateCall[pendingId];
-            return respond(this, pending, err, null, null, report);
+            return pending.send(err, null, null, report);
         }
     }
 };
@@ -210,10 +226,10 @@ internals.Policy.prototype._callGenerateFunc = function (pending, key, cached, r
                 error &&
                 !this.rule.dropOnError) {
 
-                return internals.respond(this, pending, error, cached.item, cached, report);
+                return pending.send(error, cached.item, cached, report);
             }
 
-            return internals.respond(this, pending, error, value, null, report);       // Ignored if stale value already returned
+            return pending.send(error, value, null, report);       // Ignored if stale value already returned
         };
 
         // Error (if dropOnError is not set to false) or not cached
@@ -238,19 +254,6 @@ internals.Policy.prototype._get = function (id, callback) {
     }
 
     this._cache.get({ segment: this._segment, id }, callback);
-};
-
-
-internals.respond = function (policy, pending, err, value, cached, report) {
-
-    const pendingsId = '+' + pending.id;
-    delete policy._pendings[pendingsId];
-
-    const count = pending.send(err, value, cached, report);
-
-    if (count > 0 && report.isStale !== undefined) {
-        policy.stats.hits = policy.stats.hits + count;
-    }
 };
 
 

--- a/test/policy.js
+++ b/test/policy.js
@@ -829,7 +829,7 @@ describe('Policy', () => {
                 });
             });
 
-            it('returns fresh object when cache is expired and called during a pendingGenerateTimeout period ', (done) => {
+            it('returns fresh object when cache is expired and called during a pendingGenerateTimeout period', (done) => {
 
                 let gen = 0;
 
@@ -868,7 +868,7 @@ describe('Policy', () => {
                                     policy.get('test', (err, value3, cached3, report3) => {
 
                                         expect(err).to.not.exist();
-                                        expect(value3.gen).to.equal(3);        // New
+                                        expect(value3.gen).to.equal(2);        // New
                                         done();
                                     });
                                 }, 40); // just after cache expiration


### PR DESCRIPTION
This provides a proper fix for the `pendingGenerateTimeout` invalid response issue in #177 & #184. This is done by hijacking abandoned pending generates, where the originating request has already responded (using a timeout).