### PR TITLE
Unhandled rejection on get() errors

### DIFF
--- a/lib/policy.js
+++ b/lib/policy.js
@@ -64,7 +64,8 @@ internals.Policy.prototype.get = async function (key) {     // key: string or { 
     const pending = new Pending(id, this.rule);
     this._pendings[id] = pending;
 
-    this._get(pending, key);                // Background processing
+    this._get(pending, key)                // Background processing
+        .catch(pending.reject);
 
     return await pending.promise;
 };

--- a/test/policy.js
+++ b/test/policy.js
@@ -349,6 +349,33 @@ describe('Policy', () => {
                 await expect(policy.get('test')).to.reject(Error, 'bad client');
             });
 
+            it('returns an error when get fails with type error', async () => {
+
+                let gen = 0;
+
+                const rule = {
+                    expiresIn: 100,
+                    staleIn: 20,
+                    staleTimeout: 5,
+                    generateOnReadError: false,
+                    generateTimeout: 10,
+                    generateFunc: (id) => ({ gen: ++gen })
+                };
+
+                const client = new Catbox.Client(Connection, { partition: 'test-partition' });
+                client.get = function (key) {
+
+                    global.foo.bar;
+                };
+
+                const policy = new Catbox.Policy(rule, client, 'test-segment');
+
+                await client.start();
+
+                await expect(policy.get('test')).to.reject(Error, /Cannot read property/);
+            });
+
+
             it('returns the processed cached item using manual ttl', async () => {
 
                 let gen = 0;


### PR DESCRIPTION
`Bounce.rethrow(err, 'system');` was causing undefined references in client code to generate system-level unhandled rejections and the request in question to hang.