### PR TITLE
Support ioredis client option for catbox-redis

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -26,7 +26,7 @@ module.exports = class {
         Hoek.assert(typeof engine === 'object' || typeof engine === 'function', 'engine must be an engine object or engine prototype (function)');
         Hoek.assert(typeof engine === 'function' || !options, 'Can only specify options with function engine config');
 
-        const settings = Hoek.applyToDefaults(internals.defaults, options || {});
+        const settings = Object.assign(internals.defaults, options || {});
         Hoek.assert(settings.partition.match(/^[\w\-]+$/), 'Invalid partition name:' + settings.partition);
 
         this.connection = (typeof engine === 'object' ? engine : new engine(settings));


### PR DESCRIPTION
`catbox-redis` should support passing a custom ioredis client via the `client` option, but `Hoek`'s `merge` breaks the ioredis instance - I believe because context is lost.

Using Object.assign works.