### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/policy.js
+++ b/lib/policy.js
@@ -87,7 +87,7 @@ exports = module.exports = internals.Policy = class {
     get events() {
 
         if (!this._events) {
-            this._events = new Podium(internals.events);
+            this._events = new Podium.Podium(internals.events, { validate: false });
         }
 
         return this._events;
@@ -294,7 +294,7 @@ exports = module.exports = internals.Policy = class {
         this._pendings.delete(key.id);
         pending.send(err, value, cached, report);
 
-        if (report && report.isStale !== undefined) {
+        if (report?.isStale !== undefined) {
             this.stats.hits = this.stats.hits + pending.count;
         }
     }
@@ -400,7 +400,7 @@ exports = module.exports = internals.Policy = class {
 
             // expiresIn
 
-            rule.expiresIn = options.expiresIn || 0;
+            rule.expiresIn = options.expiresIn ?? 0;
         }
 
         // generateTimeout
@@ -432,8 +432,8 @@ exports = module.exports = internals.Policy = class {
 
     static ttl(rule, created, now) {
 
-        now = now || Date.now();
-        created = created || now;
+        now = now ?? Date.now();
+        created = created ?? now;
         const age = now - created;
 
         if (age < 0) {

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/podium": "4.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/podium": "^5.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -m 5000",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Catbox;
+
+    before(async () => {
+
+        Catbox = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Catbox)).to.equal([
+            'Client',
+            'Policy',
+            'default',
+            'policy'
+        ]);
+    });
+});


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.

If this looks good, this will go out as catbox v12.